### PR TITLE
adds module_depends_on variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ GRACE Config sets up AWS Config and provides some baseline AWS Config rules that
 
 - **config.tf** contains the setup and configuration for AWS Config
 - **rules.tf** contains all of the declarations for AWS Config rules
+- **iam.tf** contains `config-service` IAM role declaration
 - **variables.tf** contains all configurable variables
 - **outputs.tf** contains all Terraform output variables
 

--- a/config.tf
+++ b/config.tf
@@ -9,6 +9,7 @@ resource "aws_config_configuration_recorder" "config" {
     all_supported                 = var.config_record_all_supported_types
     include_global_resource_types = var.config_record_global_resource_types
   }
+  depends_on = [var.module_depends_on]
 }
 
 resource "aws_config_delivery_channel" "config" {
@@ -28,29 +29,4 @@ resource "aws_config_configuration_recorder_status" "config" {
   is_enabled = var.enable_config
 
   depends_on = [aws_config_delivery_channel.config]
-}
-
-resource "aws_iam_role" "config" {
-  name = "config-service"
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "config.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_role_policy_attachment" "config" {
-  role       = aws_iam_role.config.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSConfigRole"
 }

--- a/iam.tf
+++ b/iam.tf
@@ -1,0 +1,28 @@
+##################
+# AWS IAM Role   #
+##################
+
+resource "aws_iam_role" "config" {
+  name = "config-service"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "config.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "config" {
+  role       = aws_iam_role.config.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSConfigRole"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,11 @@ variable "bucket" {
   description = "(required) The S3 bucket where AWS Config files will be stored"
 }
 
+variable "module_depends_on" {
+  type    = any
+  default = null
+}
+
 variable "bucket_prefix" {
   type        = string
   description = "(optional) The Key prefix used for AWS Config file storage"


### PR DESCRIPTION
This variable is introduced to allow `grace-config` to depend on resources that are created by a different module (even though they may not be consumed).